### PR TITLE
🔧 chore(publish.yaml): add build argument for ORIGIN secret to Docker…

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -57,6 +57,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ghcr.io/drewpayment/stacks:latest
+          args: |
+            --build-arg ORIGIN=${{ secrets.ORIGIN }}
 
       # - name: Build and push Docker image for Apple Silicon
       #   uses: docker/build-push-action@v2


### PR DESCRIPTION
… build command

The build command for the Docker image now includes the `--build-arg ORIGIN=${{ secrets.ORIGIN }}` argument. This allows the Docker image to access the `ORIGIN` secret during the build process.