### PR TITLE
feat(publish.yml): add FROM_EMAIL secret to .env file

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,7 @@ jobs:
           echo "GOOGLE_OAUTH_CLIENT_SECRET=" >> .env
           echo "GOOGLE_OAUTH_REDIRECT_URI=" >> .env
           echo "RESEND_API_KEY=${{ secrets.RESEND_API_KEY }}" >> .env
+          echo "FROM_EMAIL=${{ secrets.FROM_EMAIL }}" >> .env
           echo "CMP_CLIENT_ID=${{ secrets.CMP_CLIENT_ID }}" >> .env
           
           cat .env


### PR DESCRIPTION
This change adds the `FROM_EMAIL` secret to the `.env` file used in the publish workflow.  This allows for the configuration of the sender email address.