### PR TITLE
feat(publish.yml): add INSTANTDB_ADMIN_TOKEN and PUBLIC_APP_ID secret…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,9 @@ jobs:
           echo "PUBLIC_POSTHOG_KEY=${{ secrets.PUBLIC_POSTHOG_KEY }}" >> .env
           echo "AUTH_INITIALIZE=false" >> .env
           
+          echo "INSTANTDB_ADMIN_TOKEN=${{ secrets.INSTANTDB_ADMIN_TOKEN }}" >> .env
+          echo "PUBLIC_APP_ID=${{ secrets.PUBLIC_APP_ID }}" >> .env
+          
           cat .env
           
       - name: Setup SSH key


### PR DESCRIPTION
…s to .env file

This change adds the `INSTANTDB_ADMIN_TOKEN` and `PUBLIC_APP_ID` secrets to the `.env` file used in the GitHub Actions workflow.  This allows the workflow to access these secrets for configuration purposes.